### PR TITLE
Alteração do path do repo em relação aos demais

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,13 @@
 
 A idéia desse repositório é facilitar pra subir os repositórios relacionados ao k5 na mesma url e mesma porta, pra compartilhar cookies e informações do localStorage
 
-Os arquivos:
-- `docker-compose.yml`
-- `nginx.conf`
-
-Precisam estar na raiz onde os repositórios do k5 estão, por exemplo:
+Esse repositório precisa estar no mesmo nível que os repositórios do k5
 
 ```
 📦 k5
  ┣ 📂 ecommerce-frontend-checkout
  ┣ 📂 ecommerce-frontend-core
- ┣ 📜 docker-compose.yml
- ┗ 📜 nginx.conf
+ ┣ 📂 k5-docker-nginx
 ```
 
 E aí com o docker instalado e rodando na máquina é só rodar o comando ```docker-compose up --build```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,19 @@ version: '3'
 
 services:
   checkout:
-    container_name: 'checkout'
     ports:
       - '3001:3001'
-    build: './ecommerce-frontend-checkout'
+    build: '../ecommerce-frontend-checkout'
     volumes:
-      - './ecommerce-frontend-checkout:/src/app'
+      - '../ecommerce-frontend-checkout:/src/app'
 
   core:
-    container_name: 'core'
     ports:
       - '3000:3000'
     build:
-      context: './ecommerce-frontend-core'
+      context: '../ecommerce-frontend-core'
     volumes:
-      - './ecommerce-frontend-core:/src/app'
+      - '../ecommerce-frontend-core:/src/app'
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
- Alterei o path relativo para que o repo todo fique no mesmo nivel dos demais repos e não tenha necessidade de ser colocado em outra pasta após o clone/download